### PR TITLE
fix: remove build step from the release workflow as it doesn't exist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,6 @@ jobs:
         with:
           version: 8
           run_install: true
-      - name: Build
-        run: pnpm build
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes this error: https://github.com/warp-ds/fonts/actions/runs/5410973738/jobs/9833137037