### PR TITLE
fix(index.js): publish only minified versions of css

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,10 +10,10 @@ fs.mkdirSync(outPath, { recursive: true })
 function process(tld) {
   const css = fs.readFileSync(`./${tld.split('-')[0]}/${tld}.css`)
   const minifiedCss = minify(css);
-  const nonMinifiedFilename = path.join(outPath, tld) + '.css';
-  const minifiedFilename = path.join(outPath, tld) + '.min.css';
-  fs.writeFileSync(minifiedFilename, minifiedCss, 'utf-8');
-  fs.writeFileSync(nonMinifiedFilename, css, 'utf-8');
+  const filename = path.join(outPath, tld) + '.css';
+  const deprecatedFilename = path.join(outPath, tld) + '.min.css'; // Remove when no apps use {brand}.min.css
+  fs.writeFileSync(filename, minifiedCss, 'utf-8');
+  fs.writeFileSync(deprecatedFilename, minifiedCss, 'utf-8');
 }
 
 process('tori-fi');


### PR DESCRIPTION
We should be consistent and always publish minified css files, without min in the file name. As there might still be some apps that are requesting {brand}.min.css, we must keep the deprecated file. Once we know these files are no longer requested, we should remove them from the build.